### PR TITLE
chore: upgrade to Laravel 13.7 (Wave 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ DreamFactory Scheduler Configuration Package
 This is a system service library for the DreamFactory platform containing API for the [Scheduler](https://laravel.com/docs/master/scheduling).
 This is an add on to the DreamFactory Core library and requires the [df-core repository] (http://github.com/dreamfactorysoftware/df-core).
 
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.
+
 ## This feature requires a cron job to be configured on your system.
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Commands/ScheduleListCommand.php
+++ b/src/Commands/ScheduleListCommand.php
@@ -86,7 +86,7 @@ class ScheduleListCommand extends Command
     protected static function previousRunDate($expression)
     {
         return Carbon::instance(
-            CronExpression::factory($expression)->getPreviousRunDate()
+            (new CronExpression($expression))->getPreviousRunDate()
         );
     }
 }


### PR DESCRIPTION
## Summary
Wave 3 of the Laravel 11 -> 13 upgrade campaign. Brings df-scheduler onto Laravel 13.7 / PHP 8.3 / PHPUnit 11.5 / Testbench 11.

- **composer.json**: pin `php ^8.3`, add `laravel/helpers ^1.8` to `require`; bump dev stack to `laravel/framework ^13.7`, `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`; align `dreamfactory/df-system` constraint to `~0.6.2` (Wave 1 baseline).
- **src/Commands/ScheduleListCommand.php**: replace deprecated `CronExpression::factory($expression)` (deprecated in `dragonmantank/cron-expression` 3.0.2 and slated for removal) with `new CronExpression($expression)`.

## Source-change scope
Single one-line patch to ScheduleListCommand. No DispatchesJobs, no setupBeforeClass typos, no getDates overrides, no CorsService, no prependMiddlewareToGroup, no dispatchNow/Bus usage. Schedule + Event public API (`$event->command`, `$event->expression`, `$event->nextRunDate()`, `Schedule::command()->cron()->withoutOverlapping()->sendOutputTo()->onSuccess()->onFailure()`) is fully stable L11 -> L13.

## Validation

### Stage 1 (isolated install + autoload smoke)
- `composer validate --strict` -> clean
- `composer install` resolves `laravel/framework v13.7.0`, `phpunit/phpunit 11.5.55`, `orchestra/testbench v11.1.0`, `mockery/mockery 1.6.12`, `nunomaduro/collision v8.9.4`
- `php -l` clean across all source files
- 7 namespaced classes (ServiceProvider, ScheduleListCommand, TaskScheduler, SchedulerTask, TaskLog, SchedulerResource, ScheduleTest) + 3 helper polyfills (`array_get`, `camel_case`, `array_except`) + 4 upstream classes (Schedule, Event, CronExpression, Carbon) all autoload.
- `new CronExpression("*/5 * * * *")` runtime smoke: `getPreviousRunDate()` and `getNextRunDate()` both return correct DateTimes.

### Stage 2 (host-app integration on shift-173254)
- df-scheduler 0.4.99 path-symlinked alongside df-core 1.0.99, df-system 0.6.99
- `composer install` clean
- `php artisan package:discover` succeeds; df-scheduler discovered alongside all sibling packages
- `php artisan list` shows `schedule:list` registered to `DreamFactory\Core\Scheduler\Commands\ScheduleListCommand` (df-scheduler's override of L13's built-in, pre-existing behavior)
- 6 production classes + helpers + upstream all autoload via host-app autoloader

## Test plan
- [ ] Verify under host-app `php artisan test` once Wave 3 sibling DB-connector PRs merge
- [ ] Confirm cron-driven `schedule:run` end-to-end against a SchedulerTask row in dev environment
- [ ] Validate `schedule:list` output formatting against L13 Event property surface
- [ ] Run `schedule:run` -> task log creation flow (TaskLog onFailure handler)