### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Commands/ScheduleListCommand.php
+++ b/src/Commands/ScheduleListCommand.php
@@ -86,7 +86,7 @@ class ScheduleListCommand extends Command
     protected static function previousRunDate($expression)
     {
         return Carbon::instance(
-            CronExpression::factory($expression)->getPreviousRunDate()
+            (new CronExpression($expression))->getPreviousRunDate()
         );
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,19 +22,15 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         // add migrations
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
 
-        // Add cron job
-        $projectPath = base_path() . '/';
-        $cron = "* * * * * cd " . $projectPath . " && php artisan schedule:run >> /dev/null 2>&1";
-        try {
-            $output = shell_exec('crontab -l');
-
-            if (!Str::contains($output, $cron)) {
-                file_put_contents(storage_path() . '/crontab.txt', $output . ' ' . $cron . PHP_EOL);
-                exec('crontab ' . storage_path() . '/crontab.txt');
-            }
-
-        } catch (\Exception $e) {
-            Log::error($e->getMessage());
+        // Install the host crontab entry. This used to run on every boot
+        // (every HTTP request, every queue tick), which:
+        //  1. raced multiple workers writing the same crontab.txt,
+        //  2. ran shell_exec/exec on every request — DoS amplifier,
+        //  3. interpolated storage_path() into a shell command unquoted.
+        // We now only run from the CLI, behind an exclusive file lock,
+        // and pass the path with escapeshellarg.
+        if ($this->app->runningInConsole() && !$this->app->runningUnitTests()) {
+            $this->installCrontabEntry();
         }
 
         $this->commands([
@@ -44,6 +40,42 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app->booted(function () {
             $this->scheduleTasks();
         });
+    }
+
+    protected function installCrontabEntry(): void
+    {
+        $projectPath = base_path() . '/';
+        $cron = "* * * * * cd " . $projectPath . " && php artisan schedule:run >> /dev/null 2>&1";
+        $crontabFile = storage_path() . '/crontab.txt';
+        $lockFile = storage_path() . '/crontab.lock';
+
+        $lock = @fopen($lockFile, 'c');
+        if ($lock === false) {
+            Log::warning('df-scheduler: could not open crontab lock file at ' . $lockFile);
+            return;
+        }
+
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                // Another process is already installing the cron entry.
+                return;
+            }
+
+            $output = shell_exec('crontab -l 2>/dev/null') ?? '';
+
+            if (!Str::contains($output, $cron)) {
+                if (file_put_contents($crontabFile, $output . PHP_EOL . $cron . PHP_EOL) === false) {
+                    Log::error('df-scheduler: failed to write ' . $crontabFile);
+                    return;
+                }
+                exec('crontab ' . escapeshellarg($crontabFile));
+            }
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
     }
 
     public function register()

--- a/tests/Security/BootCrontabTest.php
+++ b/tests/Security/BootCrontabTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DreamFactory\Core\Scheduler\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-level guards on the scheduler ServiceProvider:
+ *  - crontab install must NOT run on every web request boot;
+ *  - the storage path passed to exec() must go through escapeshellarg;
+ *  - install must take a file lock to serialize concurrent workers.
+ */
+class BootCrontabTest extends TestCase
+{
+    private string $sp;
+
+    protected function setUp(): void
+    {
+        $this->sp = file_get_contents(__DIR__ . '/../../src/ServiceProvider.php');
+    }
+
+    public function testInstallIsConsoleGated(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/runningInConsole\(\).*installCrontabEntry/s',
+            $this->sp,
+            'crontab install must be gated by runningInConsole()'
+        );
+    }
+
+    public function testInstallSkipsUnitTests(): void
+    {
+        $this->assertStringContainsString(
+            'runningUnitTests',
+            $this->sp,
+            'crontab install must skip during unit tests'
+        );
+    }
+
+    public function testCrontabPathIsEscaped(): void
+    {
+        $this->assertStringContainsString(
+            'escapeshellarg($crontabFile)',
+            $this->sp,
+            'crontab path must be passed to exec() via escapeshellarg'
+        );
+    }
+
+    public function testInstallTakesExclusiveLock(): void
+    {
+        $this->assertStringContainsString('LOCK_EX', $this->sp);
+        $this->assertStringContainsString('LOCK_NB', $this->sp);
+        $this->assertStringContainsString('flock($lock', $this->sp);
+    }
+
+    public function testRawExecOfStoragePathRemoved(): void
+    {
+        // The unsafe pre-fix pattern: exec('crontab ' . storage_path() . '/crontab.txt')
+        $this->assertDoesNotMatchRegularExpression(
+            "/exec\\(\\s*'crontab '\\s*\\.\\s*storage_path\\(\\)/",
+            $this->sp,
+            'unsafe pre-fix exec call must be gone'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
